### PR TITLE
Addition of protected attribute storing all the available correlations

### DIFF
--- a/lbh15/_lbh15.py
+++ b/lbh15/_lbh15.py
@@ -57,6 +57,7 @@ class LiquidMetalInterface(ABC):
     _properties_modules_list: List[str] = []
     _custom_properties_path: Dict[str, List[str]] = {}
     _available_properties_list: List[PropertyInterface] = []
+    _available_correlations_dict: Dict[str, List[str]] = {}
     __p: float = 0
     __T: float = 0
 
@@ -391,6 +392,9 @@ class LiquidMetalInterface(ABC):
         if len(self._available_properties_list) == 0:
             self._available_properties_list = self.__load_properties()
             self._available_properties_list += self.__load_custom_properties()
+            self._available_correlations_dict = \
+                self.__extract_available_correlations(
+                    self._available_properties_list)
 
         for property_object in self._available_properties_list:
             name = property_object.name
@@ -514,10 +518,9 @@ class LiquidMetalInterface(ABC):
                                   "if any.",
                                   stacklevel=5)
                     remove_property = True
-                    corr_avail = self.__extract_available_correlations(
-                        self._available_properties_list)
-                    if key in corr_avail:
-                        self.__corr2use[key] = corr_avail[key][-1]
+                    if key in self._available_correlations_dict:
+                        self.__corr2use[key] = \
+                            self._available_correlations_dict[key][-1]
                         update_properties = True
                 else:
                     def_corr_name = self._default_corr_to_use[key]

--- a/lbh15/_lbh15.py
+++ b/lbh15/_lbh15.py
@@ -12,7 +12,6 @@ from typing import Dict
 from typing import List
 from typing import Tuple
 from typing import Union
-from contextlib import suppress
 from scipy.constants import atm
 from scipy.optimize import fsolve
 from ._decorators import typecheck_for_method
@@ -56,7 +55,7 @@ class LiquidMetalInterface(ABC):
     _default_corr_to_use: Dict[str, str] = {}
     _properties_modules_list: List[str] = []
     _custom_properties_path: Dict[str, List[str]] = {}
-    _available_properties_dict: Dict[str, PropertyInterface] = {}
+    _available_properties_list: List[PropertyInterface] = []
     __p: float = 0
     __T: float = 0
 
@@ -224,20 +223,20 @@ class LiquidMetalInterface(ABC):
 
         return rvalue, error_message
 
-#    @classmethod
-#    def properties_for_initialization(cls) -> List[str]:
-#        """
-#        List of available properties that can be used for
-#        initialization
-#
-#        Returns
-#        -------
-#        list
-#        """
-#        obj_list = cls.__load_properties()
-#        obj_list += cls.__load_custom_properties()
-#        rvalue = ['T'] + [obj_list[i].name for i in range(len(obj_list))]
-#        return list(dict.fromkeys(rvalue))
+    @classmethod
+    def properties_for_initialization(cls) -> List[str]:
+        """
+        List of available properties that can be used for
+        initialization
+
+        Returns
+        -------
+        list
+        """
+        obj_list = cls.__load_properties()
+        obj_list += cls.__load_custom_properties()
+        rvalue = ['T'] + [obj_list[i].name for i in range(len(obj_list))]
+        return list(dict.fromkeys(rvalue))
 
     @classmethod
     def correlations_available(cls) -> Dict[str, str]:
@@ -398,14 +397,12 @@ class LiquidMetalInterface(ABC):
         """
         # Build the instance dict where storing the property objects as
         # values together with their name as keys
-        if len(self._available_properties_dict) == 0:
-            available_properties = self.__load_properties()
-            available_properties += self.__load_custom_properties()
-            self._available_properties_dict = \
-                {elem.name + "__" + elem.correlation_name:elem for elem in available_properties}
+        if len(self._available_properties_list) == 0:
+            self._available_properties_list = self.__load_properties()
+            self._available_properties_list += self.__load_custom_properties()
 
-        for key, property_object in self._available_properties_dict.items():
-            name = key.split("__")[0]
+        for property_object in self._available_properties_list:
+            name = property_object.name
             # always add property if specific correlation is not specified
             add_property = (not self.__corr2use or
                             name not in self.__corr2use.keys())
@@ -436,8 +433,7 @@ class LiquidMetalInterface(ABC):
                              "time can be used for initialization. "
                              f"{len(kwargs)} were provided")
 
-        valid_prop = ['T'] + [e.split("__")[0] for e in \
-                              list(self._available_properties_dict.keys())]
+        valid_prop = ['T'] + [p.name for p in self._available_properties_list]
         input_property = list(kwargs.keys())[0]
         input_value = kwargs[input_property]
         if input_property not in valid_prop:
@@ -528,13 +524,11 @@ class LiquidMetalInterface(ABC):
                                   stacklevel=5)
                     remove_property = True
 
-                    with suppress(ValueError):
-                        self.__corr2use[key] = list(
-                            self._available_properties_dict.keys())[
-                                len(self._available_properties_dict) - 1 
-                                - list(self._available_properties_dict.keys()
-                                       )[::-1].index(key + '__')]\
-                        .split('__')[1]
+                    corr_avail = self.correlations_available()
+                    if key in corr_avail:
+                        isstr = isinstance(corr_avail[key], str)
+                        self.__corr2use[key] = (corr_avail[key] if isstr
+                                                else corr_avail[key][-1])
                         update_properties = True
                 else:
                     def_corr_name = self._default_corr_to_use[key]

--- a/lbh15/bismuth.py
+++ b/lbh15/bismuth.py
@@ -55,6 +55,7 @@ class Bismuth(LiquidMetalInterface):
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
     _available_properties_list: List[PropertyInterface] = []
+    _available_correlations_dict: Dict[str, List[str]] = {}
     _properties_modules_list: List[str] = \
         ['lbh15.properties.bismuth_thermochemical_properties\
 .solubility_in_bismuth',

--- a/lbh15/bismuth.py
+++ b/lbh15/bismuth.py
@@ -54,7 +54,7 @@ class Bismuth(LiquidMetalInterface):
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
-    _available_properties_dict: Dict[str, PropertyInterface] = {}
+    _available_properties_list: List[PropertyInterface] = []
     _properties_modules_list: List[str] = \
         ['lbh15.properties.bismuth_thermochemical_properties\
 .solubility_in_bismuth',

--- a/lbh15/bismuth.py
+++ b/lbh15/bismuth.py
@@ -11,6 +11,7 @@ from ._commons import BISMUTH_VAPORISATION_HEAT
 from ._commons import BISMUTH_MOLAR_MASS
 from ._lbh15 import LiquidMetalInterface
 from ._decorators import typecheck_for_method
+from .properties.interface import PropertyInterface
 
 
 class Bismuth(LiquidMetalInterface):
@@ -53,6 +54,7 @@ class Bismuth(LiquidMetalInterface):
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
+    _available_properties_dict: Dict[str, PropertyInterface] = {}
     _properties_modules_list: List[str] = \
         ['lbh15.properties.bismuth_thermochemical_properties\
 .solubility_in_bismuth',

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -56,7 +56,7 @@ class LBE(LiquidMetalInterface):
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
-    _available_properties_dict: Dict[str, PropertyInterface] = {}
+    _available_properties_list: List[PropertyInterface] = []
     _properties_modules_list: List[str] = \
         ['lbh15.properties.lbe_thermochemical_properties.solubility_in_lbe',
          'lbh15.properties.lbe_thermochemical_properties.diffusivity_in_lbe',

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -11,6 +11,7 @@ from ._commons import LBE_VAPORISATION_HEAT
 from ._commons import LBE_MOLAR_MASS
 from ._lbh15 import LiquidMetalInterface
 from ._decorators import typecheck_for_method
+from .properties.interface import PropertyInterface
 
 
 class LBE(LiquidMetalInterface):
@@ -55,6 +56,7 @@ class LBE(LiquidMetalInterface):
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
+    _available_properties_dict: Dict[str, PropertyInterface] = {}
     _properties_modules_list: List[str] = \
         ['lbh15.properties.lbe_thermochemical_properties.solubility_in_lbe',
          'lbh15.properties.lbe_thermochemical_properties.diffusivity_in_lbe',

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -57,6 +57,7 @@ class LBE(LiquidMetalInterface):
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
     _available_properties_list: List[PropertyInterface] = []
+    _available_correlations_dict: Dict[str, List[str]] = {}
     _properties_modules_list: List[str] = \
         ['lbh15.properties.lbe_thermochemical_properties.solubility_in_lbe',
          'lbh15.properties.lbe_thermochemical_properties.diffusivity_in_lbe',

--- a/lbh15/lead.py
+++ b/lbh15/lead.py
@@ -12,6 +12,7 @@ from ._commons import LEAD_VAPORISATION_HEAT
 from ._commons import LEAD_MOLAR_MASS
 from ._lbh15 import LiquidMetalInterface
 from ._decorators import typecheck_for_method
+from .properties.interface import PropertyInterface
 
 
 class Lead(LiquidMetalInterface):
@@ -61,6 +62,7 @@ class Lead(LiquidMetalInterface):
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
+    _available_properties_dict: Dict[str, PropertyInterface] = {}
     _properties_modules_list: List[str] = \
         ['lbh15.properties.lead_thermochemical_properties.solubility_in_lead',
          'lbh15.properties.lead_thermochemical_properties.diffusivity_in_lead',

--- a/lbh15/lead.py
+++ b/lbh15/lead.py
@@ -62,7 +62,7 @@ class Lead(LiquidMetalInterface):
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
-    _available_properties_dict: Dict[str, PropertyInterface] = {}
+    _available_properties_list: List[PropertyInterface] = []
     _properties_modules_list: List[str] = \
         ['lbh15.properties.lead_thermochemical_properties.solubility_in_lead',
          'lbh15.properties.lead_thermochemical_properties.diffusivity_in_lead',

--- a/lbh15/lead.py
+++ b/lbh15/lead.py
@@ -63,6 +63,7 @@ class Lead(LiquidMetalInterface):
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
     _available_properties_list: List[PropertyInterface] = []
+    _available_correlations_dict: Dict[str, List[str]] = {}
     _properties_modules_list: List[str] = \
         ['lbh15.properties.lead_thermochemical_properties.solubility_in_lead',
          'lbh15.properties.lead_thermochemical_properties.diffusivity_in_lead',


### PR DESCRIPTION
Insertion of the `_available_correlations_dict` attribute storing all the available correlations. This attribute is filled only once when a specific instance is created, thus accessing its content does not require any heavy operation.