### PR TITLE
[115_deepcopy_metal_object], issue - #115, Deep copy issue

### DIFF
--- a/docs/source/readme_full.rst
+++ b/docs/source/readme_full.rst
@@ -564,6 +564,8 @@ Advanced usage includes the possibility of adding new properties and new physica
 
   .. note:: It is mandatory to override the ``correlation`` method and the ``range``, ``units``, ``long_name`` and ``description`` properties.
 
+  .. note:: Properties are not allowed having the name starting with ``__``. This means that neither the name of the corresponding class nor the name provided by the ``name`` attribute must start with ``__``.
+
   .. note:: It is strongly recommended to use the ``@range_warning`` decorator so that the correlation range is checked when property is queried as liquid metal property and warning is printed, if any, as in :ref:`Basic usage`.
 
   Then, provided that the execution is performed in :code:`<execution_dir>`, one can check the correct implementation as follows:

--- a/lbh15/_lbh15.py
+++ b/lbh15/_lbh15.py
@@ -651,7 +651,10 @@ class LiquidMetalInterface(ABC):
         # Build property instances and add them to the list to return
         prop_list = []
         for prop in mod_set:
-            prop_list.append(prop())
+            prop_obj = prop()
+            # Not allowed properties whose name begins with "__"
+            if not prop_obj.name[:2] == '__':
+                prop_list.append(prop_obj)
         return prop_list
 
     @staticmethod
@@ -708,8 +711,8 @@ class LiquidMetalInterface(ABC):
         raise NotImplementedError(f"{type(self).__name__}._set_constants "
                                   "NOT IMPLEMENTED")
 
-    def __getattr__(self, name: str) -> float:
-        if name not in self.__properties:
+    def __getattr__(self, name: str):
+        if name[:2] == '__' or name not in self.__properties:
             raise AttributeError(f"'{type(self).__name__}' object "
                                  f"has no attribute '{name}'")
 

--- a/lbh15/properties/interface.py
+++ b/lbh15/properties/interface.py
@@ -37,6 +37,10 @@ class PropertyInterface(ABC):
         - :attr:`~.PropertyInterface.is_injective`: override this member only \
           in case the correlation function is not injective by returning the
           `False` value, otherwise it is considered injective.
+
+    Derived classes are not allowed having either the name starting with
+    :attr:`__` or overriding the :attr:`~.PropertyInterface.name` attribute
+    for providing a name starting with :attr:`__`.
     """
     def __init__(self):
         self.__min: float = -nan


### PR DESCRIPTION
A few modifications for making the `LiquidMetalInterface` instances deeply copiable.