### PR TITLE
Removed repeated pages

### DIFF
--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -1,7 +1,0 @@
-lbh15 Package
-=============
-
-.. toctree::
-   :maxdepth: 1
-
-   lbh15.rst

--- a/docs/source/lbh15.rst
+++ b/docs/source/lbh15.rst
@@ -1,3 +1,6 @@
+lbh15 Package
+=============
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/source/readme_full.rst
+++ b/docs/source/readme_full.rst
@@ -790,4 +790,4 @@ In the end, in :any:`properties-module` section, the *API Guide* is provided of 
 .. toctree::
    :maxdepth: 2
 
-   documentation.rst
+   lbh15.rst


### PR DESCRIPTION
Documentation updated by removing the https://newcleo-dev-team.github.io/lbh15/source/documentation.html page and modifying the https://newcleo-dev-team.github.io/lbh15/source/lbh15.html page accordingly.