### PR TITLE
Addition of LBE contamination properties

### DIFF
--- a/lbh15/__init__.py
+++ b/lbh15/__init__.py
@@ -18,6 +18,7 @@ from .properties.lbe_thermochemical_properties import solubility_in_lbe
 from .properties.lbe_thermochemical_properties import diffusivity_in_lbe
 from .properties.lbe_thermochemical_properties import lbe_thermochemical
 from .properties.lbe_thermochemical_properties import lbe_oxygen_limits
+from .properties.lbe_thermochemical_properties import lbe_contamination
 from .properties.lead_thermochemical_properties import solubility_in_lead
 from .properties.lead_thermochemical_properties import diffusivity_in_lead
 from .properties.lead_thermochemical_properties import lead_thermochemical

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -81,7 +81,7 @@ class LBE(LiquidMetalInterface):
         {'fe_sol': "gosse2014", 'ni_sol': "gosse2014",
          'cr_sol': 'gosse2014', 'o_dif': "gromov1996",
          'lim_cr': "gosse2014", 'lim_ni': "gosse2014",
-         'lim_fe': "gosse2014", 'K_LBEPo': 'ohno2006',
+         'lim_fe': "gosse2014", 'K_Po': 'ohno2006',
          'gamma_LBEPo': 'ohno2006'}
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -81,7 +81,8 @@ class LBE(LiquidMetalInterface):
         {'fe_sol': "gosse2014", 'ni_sol': "gosse2014",
          'cr_sol': 'gosse2014', 'o_dif': "gromov1996",
          'lim_cr': "gosse2014", 'lim_ni': "gosse2014",
-         'lim_fe': "gosse2014"}
+         'lim_fe': "gosse2014", 'K_LBEPo': 'ohno2006',
+         'gamma_LBEPo': 'ohno2006'}
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}
@@ -92,6 +93,7 @@ class LBE(LiquidMetalInterface):
          'lbh15.properties.lbe_thermochemical_properties.diffusivity_in_lbe',
          'lbh15.properties.lbe_thermochemical_properties.lbe_thermochemical',
          'lbh15.properties.lbe_thermochemical_properties.lbe_oxygen_limits',
+         'lbh15.properties.lbe_thermochemical_properties.lbe_contamination',
          'lbh15.properties.lbe_properties']
 
     def __init__(self, p: float = atm, **kwargs):

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -82,7 +82,8 @@ class LBE(LiquidMetalInterface):
          'cr_sol': 'gosse2014', 'o_dif': "gromov1996",
          'lim_cr': "gosse2014", 'lim_ni': "gosse2014",
          'lim_fe': "gosse2014", 'K_Po': 'ohno2006',
-         'gamma_LBEPo': 'ohno2006'}
+         'gamma_Po': 'ohno2006', 'P_PbI2': 'knacke1991',
+         'K_PbI2': 'knacke1991'}
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}

--- a/lbh15/lbe.py
+++ b/lbh15/lbe.py
@@ -83,7 +83,7 @@ class LBE(LiquidMetalInterface):
          'lim_cr': "gosse2014", 'lim_ni': "gosse2014",
          'lim_fe': "gosse2014", 'K_Po': 'ohno2006',
          'gamma_Po': 'ohno2006', 'P_PbI2': 'knacke1991',
-         'K_PbI2': 'knacke1991'}
+         'K_PbI2': 'knacke1991', 'gamma_Cs': 'lbh15'}
     _correlations_to_use: Dict[str, str] = copy.deepcopy(_default_corr_to_use)
     _roots_to_use: Dict[str, int] = {'cp': 0}
     _custom_properties_path: Dict[str, List[str]] = {}

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -1,15 +1,49 @@
 """Module with the definition of some coumpounds properties
 for contamination assessment"""
-import numpy as np
 from typing import List
+import numpy as np
 from scipy.constants import atm
 from ..interface import PropertyInterface
 from ..._decorators import range_warning
-from..._commons import LBE_MELTING_TEMPERATURE as T_m0
+from ..._commons import LBE_MELTING_TEMPERATURE as T_m0
 from ..._commons import LBE_BOILING_TEMPERATURE as T_b0
 
 
-class LBEPoloniumHenryConstantOhno2006(PropertyInterface):
+class LBEPoloniumHenryConstantInterface(PropertyInterface):
+    """
+    Liquid LBE *Polonium compound Henry constant*
+    abstract class.
+    """
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBEPo"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Polonium Henry constant long name
+        """
+        return "Henry constant of Polonium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Polonium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+
+class LBEPoloniumHenryConstantOhno2006(LBEPoloniumHenryConstantInterface):
     """
     Liquid LBE *Polonium compound Henry constant* property class
     implementing the correlation by *ohno2006*.
@@ -37,14 +71,7 @@ class LBEPoloniumHenryConstantOhno2006(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10,(- 8348 / T) + 10.5357)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "K_LBEPo_a"
+        return np.power(10, - 8348 / T + 10.5357)
 
     @property
     def correlation_name(self) -> str:
@@ -54,110 +81,16 @@ class LBEPoloniumHenryConstantOhno2006(PropertyInterface):
         return "ohno2006"
 
     @property
-    def units(self) -> str:
-        """
-        str : Henry constant unit
-        """
-        return "[Pa]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Polonium Henry constant long name
-        """
-        return "Henry constant of Polonium"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Polonium Henry constant description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Polonium 
+        List[float] : Temperature validity range of the Polonium
         Henry constant correlation function
         """
         return [723.0, 1023.0]
 
 
-class LBEPoloniumActivityCoefficientOhno2006(PropertyInterface):
-    """
-    Liquid LBE *Polonium compound activity coefficient* property class
-    implementing the correlation by *ohno2006*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *Polonium compound activity coefficient* by
-        applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            activity coefficient in :math:`[-]`
-        """
-        return np.power(10,(- 2908 / T) + 1.079)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "gamma_LBEPo_a"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "ohno2006"
-
-    @property
-    def units(self) -> str:
-        """
-        str : Activity coefficient unit
-        """
-        return "[-]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Polonium activity coefficient long name
-        """
-        return "activity coefficient of Polonium"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Polonium activity coefficient description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the Polonium 
-        activity coefficient correlation function
-        """
-        return [723.0, 877.0]
-
-
-class LBEPoloniumHenryConstantBuongiorno2003(PropertyInterface):
+class LBEPoloniumHenryConstantBuongiorno2003\
+        (LBEPoloniumHenryConstantInterface):
     """
     Liquid LBE *Polonium compound Henry constant* property class
     implementing the correlation by *buongiorno2003*.
@@ -185,14 +118,7 @@ class LBEPoloniumHenryConstantBuongiorno2003(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10,(- 6790 / T) + 1.26)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "K_LBEPo_b"
+        return np.power(10, - 6790 / T + 1.26)
 
     @property
     def correlation_name(self) -> str:
@@ -202,36 +128,96 @@ class LBEPoloniumHenryConstantBuongiorno2003(PropertyInterface):
         return "buongiorno2003"
 
     @property
-    def units(self) -> str:
-        """
-        str : Henry constant unit
-        """
-        return "[Pa]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Polonium Henry constant long name
-        """
-        return "Henry constant of Polonium"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Polonium Henry constant description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Polonium 
+        List[float] : Temperature validity range of the Polonium
         Henry constant correlation function
         """
         return [665.0, 823.0]
 
 
-class LBEPoloniumActivityCoefficient(PropertyInterface):
+class LBEPoloniumActivityCoefficientInterface(PropertyInterface):
+    """
+    Liquid LBE *Polonium compound activity coefficient*
+    abstract class.
+    """
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBEPo"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Polonium activity coefficient long name
+        """
+        return "activity coefficient of Polonium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Polonium activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+
+class LBEPoloniumActivityCoefficientOhno2006\
+        (LBEPoloniumActivityCoefficientInterface):
+    """
+    Liquid LBE *Polonium compound activity coefficient* property class
+    implementing the correlation by *ohno2006*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Polonium compound activity coefficient* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return np.power(10, - 2908 / T + 1.079)
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "ohno2006"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Polonium
+        activity coefficient correlation function
+        """
+        return [723.0, 877.0]
+
+
+class LBEPoloniumActivityCoefficient(LBEPoloniumActivityCoefficientInterface):
     """
     Liquid LBE *Polonium compound activity coefficient* property class
     implementing the correlation by *lbh15*.
@@ -259,40 +245,12 @@ class LBEPoloniumActivityCoefficient(PropertyInterface):
         float:
             activity coefficient in :math:`[-]`
         """
-        return np.power(10,(- 1830 / T) + 0.40)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "gamma_LBEPo_b"
-
-    @property
-    def units(self) -> str:
-        """
-        str : Activity coefficient unit
-        """
-        return "[-]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Polonium activity coefficient long name
-        """
-        return "activity coefficient of Polonium"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Polonium activity coefficient description
-        """
-        return f"{self.long_name} in liquid LBE"
+        return np.power(10, - 1830 / T + 0.40)
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Polonium 
+        List[float] : Temperature validity range of the Polonium
         activity coefficient correlation function
         """
         return [913.0, 1123.0]
@@ -326,7 +284,7 @@ class LBEMercuryHenryConstant(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10,(- 3332.7 / T) - 0.848 * np.log(T) + 12.6706)
+        return np.power(10, - 3332.7 / T - 0.848 * np.log(T) + 12.6706)
 
     @property
     def name(self) -> str:
@@ -460,7 +418,8 @@ class LBEMercuryVapourPressure(PropertyInterface):
         float:
             Vapour pressure in :math:`[Pa]`
         """
-        return LBEMercuryHenryConstant().correlation(T,p) / LBEMercuryActivityCoefficient().correlation(T,p)
+        return LBEMercuryHenryConstant().correlation(T, p) /\
+            LBEMercuryActivityCoefficient().correlation(T, p)
 
     @property
     def name(self) -> str:
@@ -527,7 +486,7 @@ class LBECadmiumHenryConstant(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10,(- 5711 / T) - 1.0867 * np.log(T) + 14.38)
+        return np.power(10, - 5711 / T - 1.0867 * np.log(T) + 14.38)
 
     @property
     def name(self) -> str:
@@ -661,7 +620,8 @@ class LBECadmiumVapourPressure(PropertyInterface):
         float:
             vapour pressure in :math:`[Pa]`
         """
-        return LBECadmiumHenryConstant().correlation(T,p) / LBECadmiumActivityCoefficient().correlation(T,p)
+        return LBECadmiumHenryConstant().correlation(T, p) /\
+            LBECadmiumActivityCoefficient().correlation(T, p)
 
     @property
     def name(self) -> str:
@@ -728,7 +688,7 @@ class LBEThalliumHenryConstant(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10,(- 9463 / T) - 0.892 * np.log(T) + 13.264)
+        return np.power(10, - 9463 / T - 0.892 * np.log(T) + 13.264)
 
     @property
     def name(self) -> str:
@@ -862,7 +822,8 @@ class LBEThalliumVapourPressure(PropertyInterface):
         float:
             vapour pressure in :math:`[Pa]`
         """
-        return LBEThalliumHenryConstant().correlation(T,p) / LBEThalliumActivityCoefficient().correlation(T,p)
+        return LBEThalliumHenryConstant().correlation(T, p) /\
+            LBEThalliumActivityCoefficient().correlation(T, p)
 
     @property
     def name(self) -> str:
@@ -929,7 +890,7 @@ class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10,(- 10407 / T) + 14.56)
+        return np.power(10, - 10407 / T + 14.56)
 
     @property
     def name(self) -> str:
@@ -984,8 +945,8 @@ class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *PbI2 Iodine compounds activity coefficient* by
-        applying the property correlation.
+        Returns the value of the *PbI2 Iodine compounds activity coefficient*
+        by applying the property correlation.
 
         Parameters
         ----------
@@ -1077,7 +1038,8 @@ class LBEIodineVapourPressure(PropertyInterface):
         float:
             vapour pressure in :math:`[Pa]`
         """
-        return LBEIodineHenryConstantNeuhausen2005().correlation(T,p) / LBEIodineActivityCoefficientNeuhasen2005c().correlation(T,p)
+        return LBEIodineHenryConstantNeuhausen2005().correlation(T, p) /\
+            LBEIodineActivityCoefficientNeuhasen2005c().correlation(T, p)
 
     @property
     def name(self) -> str:
@@ -1144,7 +1106,7 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         float:
             activity coefficient in :math:`[-]`
         """
-        return np.power(10,(- 2677 / T) + 0.75)
+        return np.power(10, - 2677 / T + 0.75)
 
     @property
     def name(self) -> str:
@@ -1188,7 +1150,7 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         activity coefficient correlation function.
         """
         return [723.0, 1023.0]
-   
+
 
 class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
     """
@@ -1218,7 +1180,7 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         float:
             pressure in :math:`[Pa]`
         """
-        return np.power(10,(- 4588 / T) - 1.45 * np.log(T) + 14.110)
+        return np.power(10, - 4588 / T - 1.45 * np.log(T) + 14.110)
 
     @property
     def name(self) -> str:
@@ -1292,7 +1254,7 @@ class LBERubidiumActivityCoefficient(PropertyInterface):
         float:
             activity coefficient in :math:`[-]`
         """
-        return np.power(10,-1.7)
+        return np.power(10, -1.7)
 
     @property
     def name(self) -> str:
@@ -1359,7 +1321,9 @@ class LBERubidiumHenryConstant(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return LBERubidiumVapourPressureInterfaceLandolt1960().correlation(T,p) * LBERubidiumActivityCoefficient().correlation(T,p)
+        return LBERubidiumVapourPressureInterfaceLandolt1960()\
+            .correlation(T, p) * LBERubidiumActivityCoefficient()\
+            .correlation(T, p)
 
     @property
     def name(self) -> str:

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -79,3 +79,77 @@ class LBEPoloniumHenryConstantInterfaceOhno2006(PropertyInterface):
         correlation function
         """
         return [723.0, 1023.0]
+
+
+class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
+    """
+    Liquid LBE *Mercury compounds Henry constant* property class
+    implementing the correlation by *landolt1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Mercury compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return 10**((- 3332.7 / T) + 12.6706 - 0.848 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBEHg"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "landolt1991"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Mercury Henry constant long name
+        """
+        return "Henry constant of Mercury in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Mercury Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Mercury Henry constant
+        correlation function
+        """
+        return [625.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -15,13 +15,6 @@ class LBEPoloniumHenryConstantInterface(PropertyInterface):
     abstract class.
     """
     @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "K_Po"
-
-    @property
     def units(self) -> str:
         """
         str : Henry constant unit
@@ -74,6 +67,13 @@ class LBEPoloniumHenryConstantOhno2006(LBEPoloniumHenryConstantInterface):
         return np.power(10, - 8348 / T + 10.5357)
 
     @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_Po"
+
+    @property
     def correlation_name(self) -> str:
         """
         str : Name of the correlation
@@ -121,6 +121,13 @@ class LBEPoloniumHenryConstantBuongiorno2003\
         return np.power(10, - 6790 / T + 1.26)
 
     @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_PbPo"
+
+    @property
     def correlation_name(self) -> str:
         """
         str : Name of the correlation
@@ -146,7 +153,7 @@ class LBEPoloniumActivityCoefficientInterface(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBEPo"
+        return "gamma_Po"
 
     @property
     def units(self) -> str:
@@ -258,14 +265,14 @@ class LBEPoloniumActivityCoefficient(LBEPoloniumActivityCoefficientInterface):
 
 class LBEMercuryHenryConstant(PropertyInterface):
     """
-    Liquid LBE *Mercury compound Henry constant* property class
+    Liquid LBE *dilute Mercury Henry constant* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Mercury compounds Henry constant* by
+        Returns the value of the *dilute Mercury Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -320,19 +327,19 @@ class LBEMercuryHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         Henry constant correlation function
         """
-        return [603.0, T_b0]
+        return [629.73, T_b0]
 
 
 class LBEMercuryActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Mercury compound activity coefficient* property class
+    Liquid LBE *dilute Mercury activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Mercury compounds activity coefficient* by
+        Returns the value of the *dilute Mercury activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -358,7 +365,7 @@ class LBEMercuryActivityCoefficient(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBEHg"
+        return "gamma_Hg"
 
     @property
     def units(self) -> str:
@@ -387,19 +394,19 @@ class LBEMercuryActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         activity coefficient correlation function
         """
-        return [603.0, T_b0]
+        return [629.73, T_b0]
 
 
 class LBEMercuryVapourPressure(PropertyInterface):
     """
-    Liquid LBE *Mercury compound vapour pressure* property class
+    Liquid LBE *dilute Mercury vapour pressure* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Mercury compounds vapour pressure* by
+        Returns the value of the *dilute Mercury vapour pressure* by
         applying the property correlation.
 
         Parameters
@@ -426,7 +433,7 @@ class LBEMercuryVapourPressure(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBEHg"
+        return "P_Hg"
 
     @property
     def units(self) -> str:
@@ -455,19 +462,19 @@ class LBEMercuryVapourPressure(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         vapour pressure correlation function
         """
-        return [603.0, T_b0]
+        return [629.73, T_b0]
 
 
 class LBECadmiumHenryConstant(PropertyInterface):
     """
-    Liquid LBE *Cadmium compound Henry constant* property class
+    Liquid LBE *dilute Cadmium Henry constant* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Cadmium compound Henry constant* by
+        Returns the value of the *dilute Cadmium Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -493,7 +500,7 @@ class LBECadmiumHenryConstant(PropertyInterface):
         """
         str : Name of the property
         """
-        return "K_LBECd"
+        return "K_Cd"
 
     @property
     def units(self) -> str:
@@ -527,14 +534,14 @@ class LBECadmiumHenryConstant(PropertyInterface):
 
 class LBECadmiumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Cadmium compound activity coefficient* property class
+    Liquid LBE *dilute Cadmium activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Cadmium compounds activity coefficient* by
+        Returns the value of the *dilute Cadmium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -560,7 +567,7 @@ class LBECadmiumActivityCoefficient(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBECd"
+        return "gamma_Cd"
 
     @property
     def units(self) -> str:
@@ -594,14 +601,14 @@ class LBECadmiumActivityCoefficient(PropertyInterface):
 
 class LBECadmiumVapourPressure(PropertyInterface):
     """
-    Liquid LBE *Cadmium compound vapour pressure* property class
+    Liquid LBE *dilute Cadmium vapour pressure* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Cadmium compounds vapour pressure* by
+        Returns the value of the *dilute Cadmium vapour pressure* by
         applying the property correlation.
 
         Parameters
@@ -628,7 +635,7 @@ class LBECadmiumVapourPressure(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBECd"
+        return "P_Cd"
 
     @property
     def units(self) -> str:
@@ -662,14 +669,14 @@ class LBECadmiumVapourPressure(PropertyInterface):
 
 class LBEThalliumHenryConstant(PropertyInterface):
     """
-    Liquid LBE *Thallium compounds Henry constant* property class
+    Liquid LBE *dilute Thallium Henry constant* property class
     implementing the correltion by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Thallium compounds Henry constant* by
+        Returns the value of the *dilute Thallium Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -695,7 +702,7 @@ class LBEThalliumHenryConstant(PropertyInterface):
         """
         str : Name of the property
         """
-        return "K_LBETl"
+        return "K_Tl"
 
     @property
     def units(self) -> str:
@@ -724,19 +731,19 @@ class LBEThalliumHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Thallium Henry
         constant correlation function.
         """
-        return [T_m0, T_b0]
+        return [577.0, T_b0]
 
 
 class LBEThalliumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Thallium compound activity coefficient* property class
+    Liquid LBE *dilute Thallium activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Thallium compounds activity coefficient* by
+        Returns the value of the *dilute Thallium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -762,7 +769,7 @@ class LBEThalliumActivityCoefficient(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBETl"
+        return "gamma_Tl"
 
     @property
     def units(self) -> str:
@@ -791,19 +798,19 @@ class LBEThalliumActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Thallium
         activity coefficient correlation function
         """
-        return [T_m0, T_b0]
+        return [577.0, T_b0]
 
 
 class LBEThalliumVapourPressure(PropertyInterface):
     """
-    Liquid LBE *Thallium compound vapour pressure* property class
+    Liquid LBE *dilute Thallium vapour pressure* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Thallium compounds vapour pressure* by
+        Returns the value of the *dilute Thallium vapour pressure* by
         applying the property correlation.
 
         Parameters
@@ -830,7 +837,7 @@ class LBEThalliumVapourPressure(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBETl"
+        return "P_Tl"
 
     @property
     def units(self) -> str:
@@ -859,19 +866,19 @@ class LBEThalliumVapourPressure(PropertyInterface):
         List[float] : Temperature validity range of the Thallium
         vapour pressure correlation function
         """
-        return [T_m0, T_b0]
+        return [577.0, T_b0]
 
 
 class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
     """
-    Liquid LBE *PbI2 Iodine compounds Henry constant* property class
+    Liquid LBE *monoatomic Iodine Henry constant* property class
     implementing the correlation by *neuhausen2005*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *PbI2 Iodine compounds Henry constant* by
+        Returns the value of the *monoatomic Iodine Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -897,7 +904,7 @@ class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
         """
         str : Name of the property
         """
-        return "K_LBEPbI2"
+        return "K_I"
 
     @property
     def correlation_name(self) -> str:
@@ -916,36 +923,36 @@ class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
     @property
     def long_name(self) -> str:
         """
-        str : PbI2 Iodine Henry constant long name
+        str : monoatomic Iodine Henry constant long name
         """
-        return "Henry constant of PbI2 Iodine"
+        return "Henry constant of monoatomic Iodine"
 
     @property
     def description(self) -> str:
         """
-        str : PbI2 Iodine Henry constant description
+        str : monoatomic Iodine Henry constant description
         """
         return f"{self.long_name} in liquid LBE"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the PbI2 Iodine
+        List[float] : Temperature validity range of the monoatomic Iodine
         Henry constant correlation function
         """
-        return [T_m0, T_b0]
+        return [700, T_b0]
 
 
 class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
     """
-    Liquid LBE *PbI2 Iodine compound activity coefficient* property class
+    Liquid LBE *monoatomic Iodine activity coefficient* property class
     implementing the correlation by *neuhasen2005c*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *PbI2 Iodine compounds activity coefficient*
+        Returns the value of the *monoatomic Iodine activity coefficient*
         by applying the property correlation.
 
         Parameters
@@ -971,7 +978,7 @@ class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBEPbI2"
+        return "gamma_I"
 
     @property
     def correlation_name(self) -> str:
@@ -990,36 +997,36 @@ class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
     @property
     def long_name(self) -> str:
         """
-        str : PbI2 Iodine activity coefficient long name
+        str : monoatomic Iodine activity coefficient long name
         """
-        return "Activity coefficient of PbI2 Iodine"
+        return "Activity coefficient of monoatomic Iodine"
 
     @property
     def description(self) -> str:
         """
-        str : PbI2 Iodine activity coefficient description
+        str : monoatomic Iodine activity coefficient description
         """
         return f"{self.long_name} in liquid LBE"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the PbI2 Iodine
+        List[float] : Temperature validity range of the monoatomic Iodine
         activity coefficient correlation function
         """
-        return [T_m0, T_b0]
+        return [700, T_b0]
 
 
 class LBEIodineVapourPressure(PropertyInterface):
     """
-    Liquid LBE *PbI2 Iodine compound vapour pressure* property class
+    Liquid LBE *monoatomic Iodine vapour pressure* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *PbI2 Iodine compounds vapour pressure* by
+        Returns the value of the *monoatomic Iodine vapour pressure* by
         applying the property correlation.
 
         Parameters
@@ -1046,7 +1053,7 @@ class LBEIodineVapourPressure(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBEPbI2"
+        return "P_I"
 
     @property
     def units(self) -> str:
@@ -1058,36 +1065,36 @@ class LBEIodineVapourPressure(PropertyInterface):
     @property
     def long_name(self) -> str:
         """
-        str : PbI2 Iodine vapour pressure long name
+        str : monoatomic Iodine vapour pressure long name
         """
-        return "Vapour pressure of PbI2 Iodine"
+        return "Vapour pressure of monoatomic Iodine"
 
     @property
     def description(self) -> str:
         """
-        str : PbI2 Iodine vapour pressure description
+        str : monoatomic Iodine vapour pressure description
         """
         return f"{self.long_name} in liquid LBE"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the PbI2 Iodine
+        List[float] : Temperature validity range of the monoatomic Iodine
         vapour pressure correlation function
         """
-        return [T_m0, T_b0]
+        return [700, T_b0]
 
 
 class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
     """
-    Liquid LBE *Caesium compound activity coefficient* property class
+    Liquid LBE *Caesium intermetallic compounds activity coefficient* property class
     implementing the correlation by *ohno2006*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Caesium compound Henry constant* by
+        Returns the value of the *Caesium intermetallic compounds Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -1113,7 +1120,7 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBECs"
+        return "gamma_Cs"
 
     @property
     def correlation_name(self) -> str:
@@ -1132,36 +1139,36 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
     @property
     def long_name(self) -> str:
         """
-        str : Caesium compound activity coefficient long name
+        str : Caesium intermetallic compounds activity coefficient long name
         """
-        return "Activity coefficient of Caesium compound"
+        return "Activity coefficient of Caesium intermetallic compounds"
 
     @property
     def description(self) -> str:
         """
-        str : Caesium compound activity coefficient description
+        str : Caesium intermetallic compounds activity coefficient description
         """
         return f"{self.long_name} in liquid lead"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Caesium compound
-        activity coefficient correlation function.
+        List[float] : Temperature validity range of the Caesium
+        intermetallic compounds activity coefficient correlation function.
         """
         return [723.0, 1023.0]
 
 
 class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
     """
-    Liquid LBE *Rubidium compounds vapour pressure* property class
+    Liquid LBE *Rubidium vapour pressure* property class
     implementing the correlation by *landolt1960*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Rubidium compounds vapour pressure* by
+        Returns the value of the *Rubidium vapour pressure* by
         applying the property correlation.
 
         Parameters
@@ -1187,7 +1194,7 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBERb"
+        return "P_Rb"
 
     @property
     def correlation_name(self) -> str:
@@ -1223,19 +1230,19 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         vapour pressure correlation function.
         """
-        return [T_m0, T_b0]
+        return [800, T_b0]
 
 
 class LBERubidiumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Rubidium compound activity coefficient* property class
+    Liquid LBE *Rubidium activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Rubidium compounds activity coefficient* by
+        Returns the value of the *Rubidium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -1261,7 +1268,7 @@ class LBERubidiumActivityCoefficient(PropertyInterface):
         """
         str : Name of the property
         """
-        return "gamma_LBERb"
+        return "gamma_Rb"
 
     @property
     def units(self) -> str:
@@ -1290,19 +1297,19 @@ class LBERubidiumActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         activity coefficient correlation function
         """
-        return [T_m0, T_b0]
+        return [800, T_b0]
 
 
 class LBERubidiumHenryConstant(PropertyInterface):
     """
-    Liquid LBE *Rubidium compounds Henry constant* property class
+    Liquid LBE *Rubidium Henry constant* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Rubidium compounds Henry constant* by
+        Returns the value of the *Rubidium Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -1330,7 +1337,7 @@ class LBERubidiumHenryConstant(PropertyInterface):
         """
         str : Name of the property
         """
-        return "K_LBERb"
+        return "K_Rb"
 
     @property
     def units(self) -> str:
@@ -1359,4 +1366,4 @@ class LBERubidiumHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         Henry constant correlation function.
         """
-        return [T_m0, T_b0]
+        return [800, T_b0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -227,3 +227,77 @@ class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
         correlation function
         """
         return [398.0, 1927.0]
+
+
+class LBECadmiumVapourPressureInterfaceLandolt1991(PropertyInterface):
+    """
+    Liquid LBE *Cadmium compounds vapour pressure* property class
+    implementing the correlation by *landolt1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Cadmium compounds vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            pressure in :math:`[Pa]`
+        """
+        return 0.25 * 10**((- 5711 / T) + 14.38 - 1.0867 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_LBECd"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "landolt1991"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Cadmium Vapour pressure long name
+        """
+        return "Vapour pressure of Cadmium in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Cadmium Vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Cadmium vapour
+        pressure correlation function.
+        """
+        return [398.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -301,3 +301,77 @@ class LBECadmiumVapourPressureInterfaceLandolt1991(PropertyInterface):
         pressure correlation function.
         """
         return [398.0, 1927.0]
+
+
+class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
+    """
+    Liquid LBE *Thallium compounds Henry constant* property class
+    implementing the correltion by *landolt1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Thallium compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return 10**((- 9463 / T) + 13.264 - 0.892 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBETl"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "landolt1991"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Thallium Henry constant long name
+        """
+        return "Henry constant of Thallium in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Thallium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Thallium Henry
+        constant correlation function.
+        """
+        return [398.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -523,3 +523,77 @@ class LBEIodineHenryConstantInterfaceNeuhausen2005(PropertyInterface):
         correlation function
         """
         return [398.0, 1927.0]
+
+
+class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
+    """
+    Liquid LBE *Caesium compounds activity coefficient* property class
+    implementing the correlation by *ohno2006*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Caesium compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[]`
+        """
+        return 10**((- 10407 / T) + 14.56)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBECs"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "ohno2006"
+
+    @property
+    def units(self) -> str:
+        """
+        str : activity coefficient unit
+        """
+        return "[]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Caesium activity coefficient long name
+        """
+        return "Activity coefficient of Caesium in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Caesium activity coefficient description
+        """
+        return f"{self.long_name} in liquid lead"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Caesium
+        activity coefficient correlation function.
+        """
+        return [723.0, 1023.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -153,3 +153,77 @@ class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
         correlation function
         """
         return [625.0, 1927.0]
+    
+
+class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
+    """
+    Liquid LBE *Cadmium compounds Henry constant* property class
+    implementing the correlation by *landolt1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Cadmium compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return 10**((- 5711 / T) + 14.38 - 1.0867 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBECd"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "landolt1991"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Cadmium Henry constant long name
+        """
+        return "Henry constant of Cadmium in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Cadmium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Cadmium Henry constant
+        correlation function
+        """
+        return [398.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -1,22 +1,24 @@
 """Module with the definition of some coumpounds properties
 for contamination assessment"""
-from math import log
+import numpy as np
 from typing import List
 from scipy.constants import atm
 from ..interface import PropertyInterface
 from ..._decorators import range_warning
+from..._commons import LBE_MELTING_TEMPERATURE as T_m0
+from ..._commons import LBE_BOILING_TEMPERATURE as T_b0
 
 
-class LBEPoloniumHenryConstantInterfaceOhno2006(PropertyInterface):
+class LBEPoloniumHenryConstantOhno2006(PropertyInterface):
     """
-    Liquid LBE *Polonium compounds Henry constant* property class
+    Liquid LBE *Polonium compound Henry constant* property class
     implementing the correlation by *ohno2006*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Polonium compounds Henry constant* by
+        Returns the value of the *Polonium compound Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -35,14 +37,14 @@ class LBEPoloniumHenryConstantInterfaceOhno2006(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return 10**((- 8348 / T) + 10.5357)
+        return np.power(10,(- 8348 / T) + 10.5357)
 
     @property
     def name(self) -> str:
         """
         str : Name of the property
         """
-        return "K_LBEPo"
+        return "K_LBEPo_a"
 
     @property
     def correlation_name(self) -> str:
@@ -63,7 +65,7 @@ class LBEPoloniumHenryConstantInterfaceOhno2006(PropertyInterface):
         """
         str : Polonium Henry constant long name
         """
-        return "Henry constant of Polonium in LBE"
+        return "Henry constant of Polonium"
 
     @property
     def description(self) -> str:
@@ -75,16 +77,231 @@ class LBEPoloniumHenryConstantInterfaceOhno2006(PropertyInterface):
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Polonium Henry constant
-        correlation function
+        List[float] : Temperature validity range of the Polonium 
+        Henry constant correlation function
         """
         return [723.0, 1023.0]
 
 
-class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
+class LBEPoloniumActivityCoefficientOhno2006(PropertyInterface):
     """
-    Liquid LBE *Mercury compounds Henry constant* property class
-    implementing the correlation by *landolt1991*.
+    Liquid LBE *Polonium compound activity coefficient* property class
+    implementing the correlation by *ohno2006*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Polonium compound activity coefficient* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return np.power(10,(- 2908 / T) + 1.079)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBEPo_a"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "ohno2006"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Polonium activity coefficient long name
+        """
+        return "activity coefficient of Polonium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Polonium activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Polonium 
+        activity coefficient correlation function
+        """
+        return [723.0, 877.0]
+
+
+class LBEPoloniumHenryConstantBuongiorno2003(PropertyInterface):
+    """
+    Liquid LBE *Polonium compound Henry constant* property class
+    implementing the correlation by *buongiorno2003*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Polonium compound Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return np.power(10,(- 6790 / T) + 1.26)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBEPo_b"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "buongiorno2003"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Polonium Henry constant long name
+        """
+        return "Henry constant of Polonium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Polonium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Polonium 
+        Henry constant correlation function
+        """
+        return [665.0, 823.0]
+
+
+class LBEPoloniumActivityCoefficient(PropertyInterface):
+    """
+    Liquid LBE *Polonium compound activity coefficient* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Polonium compound activity coefficient* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return np.power(10,(- 1830 / T) + 0.40)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBEPo_b"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Polonium activity coefficient long name
+        """
+        return "activity coefficient of Polonium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Polonium activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Polonium 
+        activity coefficient correlation function
+        """
+        return [913.0, 1123.0]
+
+
+class LBEMercuryHenryConstant(PropertyInterface):
+    """
+    Liquid LBE *Mercury compound Henry constant* property class
+    implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
@@ -109,7 +326,7 @@ class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return 10**((- 3332.7 / T) + 12.6706 - 0.848 * log(T))
+        return np.power(10,(- 3332.7 / T) - 0.848 * np.log(T) + 12.6706)
 
     @property
     def name(self) -> str:
@@ -117,13 +334,6 @@ class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
         str : Name of the property
         """
         return "K_LBEHg"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "landolt1991"
 
     @property
     def units(self) -> str:
@@ -137,7 +347,7 @@ class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
         """
         str : Mercury Henry constant long name
         """
-        return "Henry constant of Mercury in LBE"
+        return "Henry constant of Mercury"
 
     @property
     def description(self) -> str:
@@ -149,22 +359,156 @@ class LBEMercuryHenryConstantInterfaceLandolt1991(PropertyInterface):
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Mercury Henry constant
-        correlation function
+        List[float] : Temperature validity range of the Mercury
+        Henry constant correlation function
         """
-        return [625.0, 1927.0]
-    
+        return [603.0, T_b0]
 
-class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
+
+class LBEMercuryActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Cadmium compounds Henry constant* property class
-    implementing the correlation by *landolt1991*.
+    Liquid LBE *Mercury compound activity coefficient* property class
+    implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Cadmium compounds Henry constant* by
+        Returns the value of the *Mercury compounds activity coefficient* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return 2
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBEHg"
+
+    @property
+    def units(self) -> str:
+        """
+        str : activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Mercury activity coefficient long name
+        """
+        return "Activity coefficient of Mercury"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Mercury activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Mercury
+        activity coefficient correlation function
+        """
+        return [603.0, T_b0]
+
+
+class LBEMercuryVapourPressure(PropertyInterface):
+    """
+    Liquid LBE *Mercury compound vapour pressure* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Mercury compounds vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Vapour pressure in :math:`[Pa]`
+        """
+        return LBEMercuryHenryConstant().correlation(T,p) / LBEMercuryActivityCoefficient().correlation(T,p)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_LBEHg"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Mercury vapour pressure long name
+        """
+        return "Vapour pressure of Mercury"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Mercury vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Mercury
+        vapour pressure correlation function
+        """
+        return [603.0, T_b0]
+
+
+class LBECadmiumHenryConstant(PropertyInterface):
+    """
+    Liquid LBE *Cadmium compound Henry constant* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Cadmium compound Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -183,7 +527,7 @@ class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return 10**((- 5711 / T) + 14.38 - 1.0867 * log(T))
+        return np.power(10,(- 5711 / T) - 1.0867 * np.log(T) + 14.38)
 
     @property
     def name(self) -> str:
@@ -191,13 +535,6 @@ class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
         str : Name of the property
         """
         return "K_LBECd"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "landolt1991"
 
     @property
     def units(self) -> str:
@@ -211,7 +548,7 @@ class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
         """
         str : Cadmium Henry constant long name
         """
-        return "Henry constant of Cadmium in LBE"
+        return "Henry constant of Cadmium"
 
     @property
     def description(self) -> str:
@@ -226,13 +563,80 @@ class LBECadmiumHenryConstantInterfaceLandolt1991(PropertyInterface):
         List[float] : Temperature validity range of the Cadmium Henry constant
         correlation function
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
 
 
-class LBECadmiumVapourPressureInterfaceLandolt1991(PropertyInterface):
+class LBECadmiumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Cadmium compounds vapour pressure* property class
-    implementing the correlation by *landolt1991*.
+    Liquid LBE *Cadmium compound activity coefficient* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Cadmium compounds activity coefficient* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return 4
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBECd"
+
+    @property
+    def units(self) -> str:
+        """
+        str : activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Cadmium activity coefficient long name
+        """
+        return "Activity coefficient of Cadmium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Cadmium activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Cadmium
+        activity coefficient correlation function
+        """
+        return [T_m0, T_b0]
+
+
+class LBECadmiumVapourPressure(PropertyInterface):
+    """
+    Liquid LBE *Cadmium compound vapour pressure* property class
+    implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
@@ -255,9 +659,9 @@ class LBECadmiumVapourPressureInterfaceLandolt1991(PropertyInterface):
         Returns
         -------
         float:
-            pressure in :math:`[Pa]`
+            vapour pressure in :math:`[Pa]`
         """
-        return 0.25 * 10**((- 5711 / T) + 14.38 - 1.0867 * log(T))
+        return LBECadmiumHenryConstant().correlation(T,p) / LBECadmiumActivityCoefficient().correlation(T,p)
 
     @property
     def name(self) -> str:
@@ -267,46 +671,39 @@ class LBECadmiumVapourPressureInterfaceLandolt1991(PropertyInterface):
         return "P_LBECd"
 
     @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "landolt1991"
-
-    @property
     def units(self) -> str:
         """
-        str : Vapour pressure unit
+        str : vapour pressure unit
         """
         return "[Pa]"
 
     @property
     def long_name(self) -> str:
         """
-        str : Cadmium Vapour pressure long name
+        str : Cadmium vapour pressure long name
         """
-        return "Vapour pressure of Cadmium in LBE"
+        return "Vapour pressure of Cadmium"
 
     @property
     def description(self) -> str:
         """
-        str : Cadmium Vapour pressure description
+        str : Cadmium vapour pressure description
         """
         return f"{self.long_name} in liquid LBE"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Cadmium vapour
-        pressure correlation function.
+        List[float] : Temperature validity range of the Cadmium
+        vapour pressure correlation function
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
 
 
-class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
+class LBEThalliumHenryConstant(PropertyInterface):
     """
     Liquid LBE *Thallium compounds Henry constant* property class
-    implementing the correltion by *landolt1991*.
+    implementing the correltion by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
@@ -331,7 +728,7 @@ class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return 10**((- 9463 / T) + 13.264 - 0.892 * log(T))
+        return np.power(10,(- 9463 / T) - 0.892 * np.log(T) + 13.264)
 
     @property
     def name(self) -> str:
@@ -339,13 +736,6 @@ class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
         str : Name of the property
         """
         return "K_LBETl"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "landolt1991"
 
     @property
     def units(self) -> str:
@@ -359,7 +749,7 @@ class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
         """
         str : Thallium Henry constant long name
         """
-        return "Henry constant of Thallium in LBE"
+        return "Henry constant of Thallium"
 
     @property
     def description(self) -> str:
@@ -374,13 +764,80 @@ class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
         List[float] : Temperature validity range of the Thallium Henry
         constant correlation function.
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
 
 
-class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
+class LBEThalliumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Thallium compounds vapour pressure* property class
-    implementing the correltion by *landolt1991*.
+    Liquid LBE *Thallium compound activity coefficient* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Thallium compounds activity coefficient* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return 0.8
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBETl"
+
+    @property
+    def units(self) -> str:
+        """
+        str : activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Thallium activity coefficient long name
+        """
+        return "Activity coefficient of Thallium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Thallium activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Thallium
+        activity coefficient correlation function
+        """
+        return [T_m0, T_b0]
+
+
+class LBEThalliumVapourPressure(PropertyInterface):
+    """
+    Liquid LBE *Thallium compound vapour pressure* property class
+    implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
@@ -403,9 +860,9 @@ class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
         Returns
         -------
         float:
-            pressure in :math:`[Pa]`
+            vapour pressure in :math:`[Pa]`
         """
-        return 1.25 * 10**((- 9463 / T) + 13.264 - 0.892 * log(T))
+        return LBEThalliumHenryConstant().correlation(T,p) / LBEThalliumActivityCoefficient().correlation(T,p)
 
     @property
     def name(self) -> str:
@@ -415,16 +872,9 @@ class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
         return "P_LBETl"
 
     @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "landolt1991"
-
-    @property
     def units(self) -> str:
         """
-        str : Vapour pressure unit
+        str : vapour pressure unit
         """
         return "[Pa]"
 
@@ -433,7 +883,7 @@ class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
         """
         str : Thallium vapour pressure long name
         """
-        return "Vapour pressure of Thallium in LBE"
+        return "Vapour pressure of Thallium"
 
     @property
     def description(self) -> str:
@@ -445,22 +895,22 @@ class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the thallium
-        vapour pressure correlation function.
+        List[float] : Temperature validity range of the Thallium
+        vapour pressure correlation function
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
 
 
-class LBEIodineHenryConstantInterfaceNeuhausen2005(PropertyInterface):
+class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
     """
-    Liquid LBE *Iodine compounds Henry constant* property class
+    Liquid LBE *PbI2 Iodine compounds Henry constant* property class
     implementing the correlation by *neuhausen2005*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Iodine compounds Henry constant* by
+        Returns the value of the *PbI2 Iodine compounds Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -479,14 +929,14 @@ class LBEIodineHenryConstantInterfaceNeuhausen2005(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return 10**((- 10407 / T) + 14.56)
+        return np.power(10,(- 10407 / T) + 14.56)
 
     @property
     def name(self) -> str:
         """
         str : Name of the property
         """
-        return "K_LBEI"
+        return "K_LBEPbI2"
 
     @property
     def correlation_name(self) -> str:
@@ -505,36 +955,36 @@ class LBEIodineHenryConstantInterfaceNeuhausen2005(PropertyInterface):
     @property
     def long_name(self) -> str:
         """
-        str : Iodine Henry constant long name
+        str : PbI2 Iodine Henry constant long name
         """
-        return "Henry constant of Iodine in LBE"
+        return "Henry constant of PbI2 Iodine"
 
     @property
     def description(self) -> str:
         """
-        str : Iodine Henry constant description
+        str : PbI2 Iodine Henry constant description
         """
         return f"{self.long_name} in liquid LBE"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Iodine Henry constant
-        correlation function
+        List[float] : Temperature validity range of the PbI2 Iodine
+        Henry constant correlation function
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
 
 
-class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
+class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
     """
-    Liquid LBE *Caesium compounds activity coefficient* property class
-    implementing the correlation by *ohno2006*.
+    Liquid LBE *PbI2 Iodine compound activity coefficient* property class
+    implementing the correlation by *neuhasen2005c*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Caesium compounds Henry constant* by
+        Returns the value of the *PbI2 Iodine compounds activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -551,9 +1001,150 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         Returns
         -------
         float:
-            activity coefficient in :math:`[]`
+            activity coefficient in :math:`[-]`
         """
-        return 10**((- 10407 / T) + 14.56)
+        return 1
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_LBEPbI2"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "neuhasen2005c"
+
+    @property
+    def units(self) -> str:
+        """
+        str : activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : PbI2 Iodine activity coefficient long name
+        """
+        return "Activity coefficient of PbI2 Iodine"
+
+    @property
+    def description(self) -> str:
+        """
+        str : PbI2 Iodine activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2 Iodine
+        activity coefficient correlation function
+        """
+        return [T_m0, T_b0]
+
+
+class LBEIodineVapourPressure(PropertyInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound vapour pressure* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *PbI2 Iodine compounds vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            vapour pressure in :math:`[Pa]`
+        """
+        return LBEIodineHenryConstantNeuhausen2005().correlation(T,p) / LBEIodineActivityCoefficientNeuhasen2005c().correlation(T,p)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_LBEPbI2"
+
+    @property
+    def units(self) -> str:
+        """
+        str : vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : PbI2 Iodine vapour pressure long name
+        """
+        return "Vapour pressure of PbI2 Iodine"
+
+    @property
+    def description(self) -> str:
+        """
+        str : PbI2 Iodine vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2 Iodine
+        vapour pressure correlation function
+        """
+        return [T_m0, T_b0]
+
+
+class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
+    """
+    Liquid LBE *Caesium compound activity coefficient* property class
+    implementing the correlation by *ohno2006*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Caesium compound Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return np.power(10,(- 2677 / T) + 0.75)
 
     @property
     def name(self) -> str:
@@ -574,26 +1165,26 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         """
         str : activity coefficient unit
         """
-        return "[]"
+        return "[-]"
 
     @property
     def long_name(self) -> str:
         """
-        str : Caesium activity coefficient long name
+        str : Caesium compound activity coefficient long name
         """
-        return "Activity coefficient of Caesium in LBE"
+        return "Activity coefficient of Caesium compound"
 
     @property
     def description(self) -> str:
         """
-        str : Caesium activity coefficient description
+        str : Caesium compound activity coefficient description
         """
         return f"{self.long_name} in liquid lead"
 
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Caesium
+        List[float] : Temperature validity range of the Caesium compound
         activity coefficient correlation function.
         """
         return [723.0, 1023.0]
@@ -627,14 +1218,14 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         float:
             pressure in :math:`[Pa]`
         """
-        return 10**((- 4588 / T) + 14.110 - 1.45 * log(T))
+        return np.power(10,(- 4588 / T) - 1.45 * np.log(T) + 14.110)
 
     @property
     def name(self) -> str:
         """
         str : Name of the property
         """
-        return "P_LBERb_a"
+        return "P_LBERb"
 
     @property
     def correlation_name(self) -> str:
@@ -655,7 +1246,7 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         """
         str : Rubidium vapour pressure long name
         """
-        return "Vapour pressure of Rubidium in pure LBE"
+        return "Vapour pressure of Rubidium"
 
     @property
     def description(self) -> str:
@@ -670,19 +1261,19 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         vapour pressure correlation function.
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
 
 
-class LBERubidiumVapourPressureInterfaceHandbook(PropertyInterface):
+class LBERubidiumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *Rubidium compounds vapour pressure* property class
-    implementing the correlation by *handbook*.
+    Liquid LBE *Rubidium compound activity coefficient* property class
+    implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Rubidium compounds vapour pressure* by
+        Returns the value of the *Rubidium compounds activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -699,42 +1290,35 @@ class LBERubidiumVapourPressureInterfaceHandbook(PropertyInterface):
         Returns
         -------
         float:
-            pressure in :math:`[Pa]`
+            activity coefficient in :math:`[-]`
         """
-        return 10**(-1.7) * 10**((- 4588 / T) + 14.110 - 1.45 * log(T))
+        return np.power(10,-1.7)
 
     @property
     def name(self) -> str:
         """
         str : Name of the property
         """
-        return "P_LBERb_b"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "handbook"
+        return "gamma_LBERb"
 
     @property
     def units(self) -> str:
         """
-        str : Vapour pressure unit
+        str : activity coefficient unit
         """
-        return "[Pa]"
+        return "[-]"
 
     @property
     def long_name(self) -> str:
         """
-        str : Rubidium vapour pressure long name
+        str : Rubidium activity coefficient long name
         """
-        return "Vapour pressure of Rubidium in pure LBE"
+        return "Activity coefficient of Rubidium"
 
     @property
     def description(self) -> str:
         """
-        str : Rubidium vapour pressure description
+        str : Rubidium activity coefficient description
         """
         return f"{self.long_name} in liquid LBE"
 
@@ -742,6 +1326,73 @@ class LBERubidiumVapourPressureInterfaceHandbook(PropertyInterface):
     def range(self) -> List[float]:
         """
         List[float] : Temperature validity range of the Rubidium
-        vapour pressure correlation function.
+        activity coefficient correlation function
         """
-        return [398.0, 1927.0]
+        return [T_m0, T_b0]
+
+
+class LBERubidiumHenryConstant(PropertyInterface):
+    """
+    Liquid LBE *Rubidium compounds Henry constant* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Rubidium compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return LBERubidiumVapourPressureInterfaceLandolt1960().correlation(T,p) * LBERubidiumActivityCoefficient().correlation(T,p)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBERb"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Rubidium Henry constant long name
+        """
+        return "Henry constant of Rubidium"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Rubidium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Rubidium
+        Henry constant correlation function.
+        """
+        return [T_m0, T_b0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -449,3 +449,77 @@ class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
         vapour pressure correlation function.
         """
         return [398.0, 1927.0]
+
+
+class LBEIodineHenryConstantInterfaceNeuhausen2005(PropertyInterface):
+    """
+    Liquid LBE *Iodine compounds Henry constant* property class
+    implementing the correlation by *neuhausen2005*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Iodine compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return 10**((- 10407 / T) + 14.56)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBEI"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "neuheusen2005"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Iodine Henry constant long name
+        """
+        return "Henry constant of Iodine in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Iodine Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Iodine Henry constant
+        correlation function
+        """
+        return [398.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -19,7 +19,7 @@ class LBEPoloniumHenryConstantInterface(PropertyInterface):
         """
         str : Name of the property
         """
-        return "K_LBEPo"
+        return "K_Po"
 
     @property
     def units(self) -> str:
@@ -45,14 +45,14 @@ class LBEPoloniumHenryConstantInterface(PropertyInterface):
 
 class LBEPoloniumHenryConstantOhno2006(LBEPoloniumHenryConstantInterface):
     """
-    Liquid LBE *Polonium compound Henry constant* property class
+    Liquid LBE *elemental Polonium Henry constant* property class
     implementing the correlation by *ohno2006*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Polonium compound Henry constant* by
+        Returns the value of the *elemental Polonium Henry constant* by
         applying the property correlation.
 
         Parameters

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -145,7 +145,7 @@ class LBEPoloniumHenryConstantBuongiorno2003\
 
 class LBEPoloniumActivityCoefficientInterface(PropertyInterface):
     """
-    Liquid LBE *Polonium compound activity coefficient*
+    Liquid LBE *elemental Polonium activity coefficient*
     abstract class.
     """
     @property
@@ -167,7 +167,7 @@ class LBEPoloniumActivityCoefficientInterface(PropertyInterface):
         """
         str : Polonium activity coefficient long name
         """
-        return "activity coefficient of Polonium"
+        return "Activity coefficient of elemental Polonium"
 
     @property
     def description(self) -> str:
@@ -180,14 +180,14 @@ class LBEPoloniumActivityCoefficientInterface(PropertyInterface):
 class LBEPoloniumActivityCoefficientOhno2006\
         (LBEPoloniumActivityCoefficientInterface):
     """
-    Liquid LBE *Polonium compound activity coefficient* property class
+    Liquid LBE *elemental Polonium activity coefficient* property class
     implementing the correlation by *ohno2006*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Polonium compound activity coefficient* by
+        Returns the value of the *elemental Polonium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -218,22 +218,22 @@ class LBEPoloniumActivityCoefficientOhno2006\
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Polonium
-        activity coefficient correlation function
+        List[float] : Temperature validity range of the elemental
+        Polonium activity coefficient correlation function
         """
         return [723.0, 877.0]
 
 
 class LBEPoloniumActivityCoefficient(LBEPoloniumActivityCoefficientInterface):
     """
-    Liquid LBE *Polonium compound activity coefficient* property class
+    Liquid LBE *elemental Polonium activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Polonium compound activity coefficient* by
+        Returns the value of the *elemental Polonium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -257,8 +257,8 @@ class LBEPoloniumActivityCoefficient(LBEPoloniumActivityCoefficientInterface):
     @property
     def range(self) -> List[float]:
         """
-        List[float] : Temperature validity range of the Polonium
-        activity coefficient correlation function
+        List[float] : Temperature validity range of the elemental
+        Polonium activity coefficient correlation function
         """
         return [913.0, 1123.0]
 
@@ -327,7 +327,7 @@ class LBEMercuryHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         Henry constant correlation function
         """
-        return [629.73, T_b0]
+        return [603.0, T_b0]
 
 
 class LBEMercuryActivityCoefficient(PropertyInterface):
@@ -394,7 +394,7 @@ class LBEMercuryActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         activity coefficient correlation function
         """
-        return [629.73, T_b0]
+        return [603.0, T_b0]
 
 
 class LBEMercuryVapourPressure(PropertyInterface):
@@ -462,7 +462,7 @@ class LBEMercuryVapourPressure(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         vapour pressure correlation function
         """
-        return [629.73, T_b0]
+        return [603.0, T_b0]
 
 
 class LBECadmiumHenryConstant(PropertyInterface):
@@ -1316,80 +1316,6 @@ class LBEIodineHenryConstantNeuhausen2005(LBEIodineHenryConstantInterface):
         return [700, T_b0]
 
 
-
-    """
-    Liquid LBE *monoatomic Iodine activity coefficient* property class
-    implementing the correlation by *neuhasen2005c*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *monoatomic Iodine activity coefficient*
-        by applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            activity coefficient in :math:`[-]`
-        """
-        return 1
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "gamma_I"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "neuhasen2005c"
-
-    @property
-    def units(self) -> str:
-        """
-        str : activity coefficient unit
-        """
-        return "[-]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : monoatomic Iodine activity coefficient long name
-        """
-        return "Activity coefficient of monoatomic Iodine"
-
-    @property
-    def description(self) -> str:
-        """
-        str : monoatomic Iodine activity coefficient description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the monoatomic Iodine
-        activity coefficient correlation function
-        """
-        return [700, T_b0]
-
-
 class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
     """
     Liquid LBE *Caesium intermetallic compounds activity coefficient* property class
@@ -1535,7 +1461,7 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         vapour pressure correlation function.
         """
-        return [800, T_b0]
+        return [T_m0, T_b0]
 
 
 class LBERubidiumActivityCoefficient(PropertyInterface):
@@ -1602,7 +1528,7 @@ class LBERubidiumActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         activity coefficient correlation function
         """
-        return [800, T_b0]
+        return [T_m0, T_b0]
 
 
 class LBERubidiumHenryConstant(PropertyInterface):
@@ -1671,4 +1597,4 @@ class LBERubidiumHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         Henry constant correlation function.
         """
-        return [800, T_b0]
+        return [T_m0, T_b0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -375,3 +375,77 @@ class LBEThalliumHenryConstantInterfaceLandolt1991(PropertyInterface):
         constant correlation function.
         """
         return [398.0, 1927.0]
+
+
+class LBEThalliumVapourPressureInterfaceLandolt1991(PropertyInterface):
+    """
+    Liquid LBE *Thallium compounds vapour pressure* property class
+    implementing the correltion by *landolt1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Thallium compounds vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            pressure in :math:`[Pa]`
+        """
+        return 1.25 * 10**((- 9463 / T) + 13.264 - 0.892 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_LBETl"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "landolt1991"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Thallium vapour pressure long name
+        """
+        return "Vapour pressure of Thallium in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Thallium vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the thallium
+        vapour pressure correlation function.
+        """
+        return [398.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -118,7 +118,7 @@ class LBEPoloniumHenryConstantBuongiorno2003\
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10, - 6790 / T + 1.26)
+        return np.power(10, - 6790 / T + 8.46)
 
     @property
     def name(self) -> str:
@@ -138,7 +138,7 @@ class LBEPoloniumHenryConstantBuongiorno2003\
     def range(self) -> List[float]:
         """
         List[float] : Temperature validity range of the Polonium
-        Henry constant correlation function
+        compound Henry constant correlation function
         """
         return [665.0, 823.0]
 
@@ -265,14 +265,14 @@ class LBEPoloniumActivityCoefficient(LBEPoloniumActivityCoefficientInterface):
 
 class LBEMercuryHenryConstant(PropertyInterface):
     """
-    Liquid LBE *dilute Mercury Henry constant* property class
+    Liquid LBE *Mercury Henry constant* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *dilute Mercury Henry constant* by
+        Returns the value of the *Mercury Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -291,14 +291,14 @@ class LBEMercuryHenryConstant(PropertyInterface):
         float:
             Henry constant in :math:`[Pa]`
         """
-        return np.power(10, - 3332.7 / T - 0.848 * np.log(T) + 12.6706)
+        return np.power(10, - 3332.7 / T - 0.848 * np.log(T) + 12.9716)
 
     @property
     def name(self) -> str:
         """
         str : Name of the property
         """
-        return "K_LBEHg"
+        return "K_Hg"
 
     @property
     def units(self) -> str:
@@ -327,19 +327,20 @@ class LBEMercuryHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         Henry constant correlation function
         """
-        return [603.0, T_b0]
+        return [603 - 0.05 * (T_b0 - T_m0),
+                603 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBEMercuryActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *dilute Mercury activity coefficient* property class
+    Liquid LBE *Mercury activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *dilute Mercury activity coefficient* by
+        Returns the value of the *Mercury activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -394,87 +395,20 @@ class LBEMercuryActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Mercury
         activity coefficient correlation function
         """
-        return [603.0, T_b0]
-
-
-class LBEMercuryVapourPressure(PropertyInterface):
-    """
-    Liquid LBE *dilute Mercury vapour pressure* property class
-    implementing the correlation by *lbh15*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *dilute Mercury vapour pressure* by
-        applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            Vapour pressure in :math:`[Pa]`
-        """
-        return LBEMercuryHenryConstant().correlation(T, p) /\
-            LBEMercuryActivityCoefficient().correlation(T, p)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "P_Hg"
-
-    @property
-    def units(self) -> str:
-        """
-        str : Vapour pressure unit
-        """
-        return "[Pa]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Mercury vapour pressure long name
-        """
-        return "Vapour pressure of Mercury"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Mercury vapour pressure description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the Mercury
-        vapour pressure correlation function
-        """
-        return [603.0, T_b0]
+        return [603 - 0.05 * (T_b0 - T_m0),
+                603 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBECadmiumHenryConstant(PropertyInterface):
     """
-    Liquid LBE *dilute Cadmium Henry constant* property class
+    Liquid LBE *Cadmium Henry constant* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *dilute Cadmium Henry constant* by
+        Returns the value of the *Cadmium Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -529,19 +463,20 @@ class LBECadmiumHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Cadmium Henry constant
         correlation function
         """
-        return [T_m0, T_b0]
+        return [773 - 0.05 * (T_b0 - T_m0),
+                773 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBECadmiumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *dilute Cadmium activity coefficient* property class
+    Liquid LBE *Cadmium activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *dilute Cadmium activity coefficient* by
+        Returns the value of the *Cadmium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -596,87 +531,20 @@ class LBECadmiumActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Cadmium
         activity coefficient correlation function
         """
-        return [T_m0, T_b0]
+        return [773 - 0.05 * (T_b0 - T_m0),
+                773 + 0.05 * (T_b0 - T_m0)]
 
 
-class LBECadmiumVapourPressure(PropertyInterface):
+class LBEThalliumHenryConstant(PropertyInterface):
     """
-    Liquid LBE *dilute Cadmium vapour pressure* property class
+    Liquid LBE *Thallium Henry constant* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *dilute Cadmium vapour pressure* by
-        applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            vapour pressure in :math:`[Pa]`
-        """
-        return LBECadmiumHenryConstant().correlation(T, p) /\
-            LBECadmiumActivityCoefficient().correlation(T, p)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "P_Cd"
-
-    @property
-    def units(self) -> str:
-        """
-        str : vapour pressure unit
-        """
-        return "[Pa]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Cadmium vapour pressure long name
-        """
-        return "Vapour pressure of Cadmium"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Cadmium vapour pressure description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the Cadmium
-        vapour pressure correlation function
-        """
-        return [T_m0, T_b0]
-
-
-class LBEThalliumHenryConstant(PropertyInterface):
-    """
-    Liquid LBE *dilute Thallium Henry constant* property class
-    implementing the correltion by *lbh15*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *dilute Thallium Henry constant* by
+        Returns the value of the *Thallium Henry constant* by
         applying the property correlation.
 
         Parameters
@@ -731,19 +599,20 @@ class LBEThalliumHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Thallium Henry
         constant correlation function.
         """
-        return [577.0, T_b0]
+        return [773 - 0.05 * (T_b0 - T_m0),
+                773 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBEThalliumActivityCoefficient(PropertyInterface):
     """
-    Liquid LBE *dilute Thallium activity coefficient* property class
+    Liquid LBE *Thallium activity coefficient* property class
     implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *dilute Thallium activity coefficient* by
+        Returns the value of the *Thallium activity coefficient* by
         applying the property correlation.
 
         Parameters
@@ -798,80 +667,13 @@ class LBEThalliumActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Thallium
         activity coefficient correlation function
         """
-        return [577.0, T_b0]
-
-
-class LBEThalliumVapourPressure(PropertyInterface):
-    """
-    Liquid LBE *dilute Thallium vapour pressure* property class
-    implementing the correlation by *lbh15*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *dilute Thallium vapour pressure* by
-        applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            vapour pressure in :math:`[Pa]`
-        """
-        return LBEThalliumHenryConstant().correlation(T, p) /\
-            LBEThalliumActivityCoefficient().correlation(T, p)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "P_Tl"
-
-    @property
-    def units(self) -> str:
-        """
-        str : vapour pressure unit
-        """
-        return "[Pa]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : Thallium vapour pressure long name
-        """
-        return "Vapour pressure of Thallium"
-
-    @property
-    def description(self) -> str:
-        """
-        str : Thallium vapour pressure description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the Thallium
-        vapour pressure correlation function
-        """
-        return [577.0, T_b0]
+        return [773 - 0.05 * (T_b0 - T_m0),
+                773 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBEIodineVapourPressureInterface(PropertyInterface):
     """
-    Liquid LBE *PbI2 Iodine compound vapour pressure* 
+    Liquid LBE *PbI2 Iodine compound vapour pressure*
     abstract class.
     """
     @property
@@ -946,7 +748,7 @@ class LBEIodineVapourPressureKonings1996(LBEIodineVapourPressureInterface):
         List[float] : Temperature validity range of the PbI2
         Iodine compound vapour pressure correlation function.
         """
-        return [T_m0, 697.0]
+        return [580.0, 697.0]
 
 
 class LBEIodineVapourPressureKnacke1991(LBEIodineVapourPressureInterface):
@@ -992,68 +794,7 @@ class LBEIodineVapourPressureKnacke1991(LBEIodineVapourPressureInterface):
         List[float] : Temperature validity range of the PbI2
         Iodine compound vapour pressure correlation function.
         """
-        return [697.0, T_b0]
-
-
-class LBEIodineVapourPressure(LBEIodineVapourPressureInterface):
-    """
-    Liquid LBE *monoatomic Iodine vapour pressure* property class
-    implementing the correlation by *lbh15*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *monoatomic Iodine vapour pressure* by
-        applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            vapour pressure in :math:`[Pa]`
-        """
-        return LBEIodineHenryConstantNeuhausen2005().correlation(T, p) /\
-            LBEIodineActivityCoefficient().correlation(T, p)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "P_I"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : monoatomic Iodine vapour pressure long name
-        """
-        return "Vapour pressure of monoatomic Iodine"
-
-    @property
-    def description(self) -> str:
-        """
-        str : monoatomic Iodine vapour pressure description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the monoatomic Iodine
-        vapour pressure correlation function
-        """
-        return [700, T_b0]
+        return [697.0, 1120.0]
 
 
 class LBEIodineActivityCoefficient(PropertyInterface):
@@ -1120,7 +861,7 @@ class LBEIodineActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the PbI2 Iodine
         compound activity coefficient correlation function
         """
-        return [T_m0, T_b0]
+        return [580.0, 1120.0]
 
 
 class LBEIodineHenryConstantInterface(PropertyInterface):
@@ -1200,7 +941,7 @@ class LBEIodineHenryConstantKonings1996(LBEIodineHenryConstantInterface):
         List[float] : Temperature validity range of the PbI2 Iodine
         compound Henry constant correlation function
         """
-        return [T_m0, 697.0]
+        return [580.0, 697.0]
 
 
 class LBEIodineHenryConstantKnacke1991(LBEIodineHenryConstantInterface):
@@ -1246,7 +987,7 @@ class LBEIodineHenryConstantKnacke1991(LBEIodineHenryConstantInterface):
         List[float] : Temperature validity range of the PbI2 Iodine
         compound Henry constant correlation function
         """
-        return [697.0, T_b0]
+        return [697.0, 1120.0]
 
 
 class LBEIodineHenryConstantNeuhausen2005(LBEIodineHenryConstantInterface):
@@ -1291,7 +1032,7 @@ class LBEIodineHenryConstantNeuhausen2005(LBEIodineHenryConstantInterface):
         """
         str : Name of the correlation
         """
-        return "neuheusen2005"
+        return "neuhausen2005"
 
     @property
     def long_name(self) -> str:
@@ -1313,20 +1054,20 @@ class LBEIodineHenryConstantNeuhausen2005(LBEIodineHenryConstantInterface):
         List[float] : Temperature validity range of the monoatomic Iodine
         Henry constant correlation function
         """
-        return [700, T_b0]
+        return [700, 1120.0]
 
 
-class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
+class LBECaesiumHenryConstant(PropertyInterface):
     """
-    Liquid LBE *Caesium intermetallic compounds activity coefficient* property class
-    implementing the correlation by *ohno2006*.
+    Liquid LBE *Caesium intermetallic compounds Henry constant*
+    property class implementing the correlation by *lbh15*.
     """
     @range_warning
     def correlation(self, T: float, p: float = atm,
                     verbose: bool = False) -> float:
         """
-        Returns the value of the *Caesium intermetallic compounds Henry constant* by
-        applying the property correlation.
+        Returns the value of the *Caesium intermetallic compounds
+        Henry constant* by applying the property correlation.
 
         Parameters
         ----------
@@ -1342,9 +1083,53 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         Returns
         -------
         float:
-            activity coefficient in :math:`[-]`
+            Henry constant in :math:`[Pa]`
         """
-        return np.power(10, - 2677 / T + 0.75)
+        return np.power(10, - 4980 / T - 9.323 * np.log(T)
+                        + 0.004473 * T - 8.684e-7 * T**2 + 33.07)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_Cs"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Caesium Henry constant long name
+        """
+        return "Henry constant of Caesium intermettalic compounds"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Caesium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Caesium
+        intermettalic compounds Henry constant correlation function.
+        """
+        return [643, 933]
+
+
+class LBECaesiumActivityCoefficientInterface(PropertyInterface):
+    """
+    Liquid LBE *Caesium intermetallic compounds activity coefficient*
+    property abstract class.
+    """
 
     @property
     def name(self) -> str:
@@ -1352,13 +1137,6 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         str : Name of the property
         """
         return "gamma_Cs"
-
-    @property
-    def correlation_name(self) -> str:
-        """
-        str : Name of the correlation
-        """
-        return "ohno2006"
 
     @property
     def units(self) -> str:
@@ -1380,6 +1158,84 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         str : Caesium intermetallic compounds activity coefficient description
         """
         return f"{self.long_name} in liquid LBE"
+
+
+class LBECaesiumActivityCoefficient(LBECaesiumActivityCoefficientInterface):
+    """
+    Liquid LBE *Caesium intermetallic compounds activity coefficient* property
+    class implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Caesium intermetallic compounds Henry
+        constant* by applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return np.power(10, -1.5)
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Caesium
+        intermetallic compounds activity coefficient correlation function.
+        """
+        return [643, 933]
+
+
+class LBECaesiumActivityCoefficientOhno2006\
+      (LBECaesiumActivityCoefficientInterface):
+    """
+    Liquid LBE *Caesium intermetallic compounds activity coefficient* property
+    class implementing the correlation by *ohno2006*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Caesium intermetallic compounds Henry
+        constant* by applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return np.power(10, - 2677 / T + 0.75)
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "ohno2006"
 
     @property
     def range(self) -> List[float]:
@@ -1461,7 +1317,8 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         vapour pressure correlation function.
         """
-        return [T_m0, T_b0]
+        return [873 - 0.05 * (T_b0 - T_m0),
+                873 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBERubidiumActivityCoefficient(PropertyInterface):
@@ -1492,7 +1349,7 @@ class LBERubidiumActivityCoefficient(PropertyInterface):
         float:
             activity coefficient in :math:`[-]`
         """
-        return np.power(10, -1.7)
+        return 0.02
 
     @property
     def name(self) -> str:
@@ -1528,7 +1385,8 @@ class LBERubidiumActivityCoefficient(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         activity coefficient correlation function
         """
-        return [T_m0, T_b0]
+        return [873 - 0.05 * (T_b0 - T_m0),
+                873 + 0.05 * (T_b0 - T_m0)]
 
 
 class LBERubidiumHenryConstant(PropertyInterface):
@@ -1597,4 +1455,5 @@ class LBERubidiumHenryConstant(PropertyInterface):
         List[float] : Temperature validity range of the Rubidium
         Henry constant correlation function.
         """
-        return [T_m0, T_b0]
+        return [873 - 0.05 * (T_b0 - T_m0),
+                873 + 0.05 * (T_b0 - T_m0)]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -634,7 +634,7 @@ class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBERb"
+        return "P_LBERb_a"
 
     @property
     def correlation_name(self) -> str:
@@ -708,7 +708,7 @@ class LBERubidiumVapourPressureInterfaceHandbook(PropertyInterface):
         """
         str : Name of the property
         """
-        return "P_LBERb"
+        return "P_LBERb_b"
 
     @property
     def correlation_name(self) -> str:

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -597,3 +597,151 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         activity coefficient correlation function.
         """
         return [723.0, 1023.0]
+   
+
+class LBERubidiumVapourPressureInterfaceLandolt1960(PropertyInterface):
+    """
+    Liquid LBE *Rubidium compounds vapour pressure* property class
+    implementing the correlation by *landolt1960*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Rubidium compounds vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            pressure in :math:`[Pa]`
+        """
+        return 10**((- 4588 / T) + 14.110 - 1.45 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_LBERb"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "landolt1960"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Rubidium vapour pressure long name
+        """
+        return "Vapour pressure of Rubidium in pure LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Rubidium vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Rubidium
+        vapour pressure correlation function.
+        """
+        return [398.0, 1927.0]
+
+
+class LBERubidiumVapourPressureInterfaceHandbook(PropertyInterface):
+    """
+    Liquid LBE *Rubidium compounds vapour pressure* property class
+    implementing the correlation by *handbook*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Rubidium compounds vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            pressure in :math:`[Pa]`
+        """
+        return 10**(-1.7) * 10**((- 4588 / T) + 14.110 - 1.45 * log(T))
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_LBERb"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "handbook"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Rubidium vapour pressure long name
+        """
+        return "Vapour pressure of Rubidium in pure LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Rubidium vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Rubidium
+        vapour pressure correlation function.
+        """
+        return [398.0, 1927.0]

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -869,7 +869,387 @@ class LBEThalliumVapourPressure(PropertyInterface):
         return [577.0, T_b0]
 
 
-class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
+class LBEIodineVapourPressureInterface(PropertyInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound vapour pressure* 
+    abstract class.
+    """
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_PbI2"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Vapour pressure unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : PbI2 Iodine vapour pressure long name
+        """
+        return "Vapour pressure of PbI2 Iodine compound"
+
+    @property
+    def description(self) -> str:
+        """
+        str : PbI2 Iodine compound vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+
+class LBEIodineVapourPressureKonings1996(LBEIodineVapourPressureInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound vapour pressure* property class
+    implementing the correlation by *konings1996*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *PbI2 Iodine compound vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            pressure in :math:`[Pa]`
+        """
+        return np.power(10, - 8691 / T + 13.814)
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "konings1996"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2
+        Iodine compound vapour pressure correlation function.
+        """
+        return [T_m0, 697.0]
+
+
+class LBEIodineVapourPressureKnacke1991(LBEIodineVapourPressureInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound vapour pressure* property class
+    implementing the correlation by *knacke1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *PbI2 Iodine compound vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            pressure in :math:`[Pa]`
+        """
+        return np.power(10, - 9087 / T - 6.16 * np.log(T) + 31.897)
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "knacke1991"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2
+        Iodine compound vapour pressure correlation function.
+        """
+        return [697.0, T_b0]
+
+
+class LBEIodineVapourPressure(LBEIodineVapourPressureInterface):
+    """
+    Liquid LBE *monoatomic Iodine vapour pressure* property class
+    implementing the correlation by *lbh15*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *monoatomic Iodine vapour pressure* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            vapour pressure in :math:`[Pa]`
+        """
+        return LBEIodineHenryConstantNeuhausen2005().correlation(T, p) /\
+            LBEIodineActivityCoefficient().correlation(T, p)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "P_I"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : monoatomic Iodine vapour pressure long name
+        """
+        return "Vapour pressure of monoatomic Iodine"
+
+    @property
+    def description(self) -> str:
+        """
+        str : monoatomic Iodine vapour pressure description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the monoatomic Iodine
+        vapour pressure correlation function
+        """
+        return [700, T_b0]
+
+
+class LBEIodineActivityCoefficient(PropertyInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound activity coefficient*
+    property class implementing the suggestion by *handbook*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *PbI2 Iodine compound activity coefficient*
+        by applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            activity coefficient in :math:`[-]`
+        """
+        return 1
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "gamma_PbI2"
+
+    @property
+    def units(self) -> str:
+        """
+        str : activity coefficient unit
+        """
+        return "[-]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : PbI2 iodine compound activity coefficient long name
+        """
+        return "Activity coefficient of PbI2 Iodine compound"
+
+    @property
+    def description(self) -> str:
+        """
+        str : PbI2 Iodine compound activity coefficient description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2 Iodine
+        compound activity coefficient correlation function
+        """
+        return [T_m0, T_b0]
+
+
+class LBEIodineHenryConstantInterface(PropertyInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound Henry constant*
+    abstract class.
+    """
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_PbI2"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : PbI2 Iodine compound Henry constant long name
+        """
+        return "Henry constant of PbI2 Iodine compound"
+
+    @property
+    def description(self) -> str:
+        """
+        str : PbI2 Iodine compound Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+
+class LBEIodineHenryConstantKonings1996(LBEIodineHenryConstantInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound Henry constant*
+    property class implementing the correlation by *konings1996*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *PbI2 Iodine compound Henry constant*
+        by applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return LBEIodineVapourPressureKonings1996().correlation(T, p)
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "konings1996"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2 Iodine
+        compound Henry constant correlation function
+        """
+        return [T_m0, 697.0]
+
+
+class LBEIodineHenryConstantKnacke1991(LBEIodineHenryConstantInterface):
+    """
+    Liquid LBE *PbI2 Iodine compound Henry constant*
+    property class implementing the correlation by *knacke1991*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *PbI2 Iodine compound Henry constant*
+        by applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return LBEIodineVapourPressureKnacke1991().correlation(T, p)
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "knacke1991"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the PbI2 Iodine
+        compound Henry constant correlation function
+        """
+        return [697.0, T_b0]
+
+
+class LBEIodineHenryConstantNeuhausen2005(LBEIodineHenryConstantInterface):
     """
     Liquid LBE *monoatomic Iodine Henry constant* property class
     implementing the correlation by *neuhausen2005*.
@@ -914,13 +1294,6 @@ class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
         return "neuheusen2005"
 
     @property
-    def units(self) -> str:
-        """
-        str : Henry constant unit
-        """
-        return "[Pa]"
-
-    @property
     def long_name(self) -> str:
         """
         str : monoatomic Iodine Henry constant long name
@@ -943,7 +1316,7 @@ class LBEIodineHenryConstantNeuhausen2005(PropertyInterface):
         return [700, T_b0]
 
 
-class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
+
     """
     Liquid LBE *monoatomic Iodine activity coefficient* property class
     implementing the correlation by *neuhasen2005c*.
@@ -1017,74 +1390,6 @@ class LBEIodineActivityCoefficientNeuhasen2005c(PropertyInterface):
         return [700, T_b0]
 
 
-class LBEIodineVapourPressure(PropertyInterface):
-    """
-    Liquid LBE *monoatomic Iodine vapour pressure* property class
-    implementing the correlation by *lbh15*.
-    """
-    @range_warning
-    def correlation(self, T: float, p: float = atm,
-                    verbose: bool = False) -> float:
-        """
-        Returns the value of the *monoatomic Iodine vapour pressure* by
-        applying the property correlation.
-
-        Parameters
-        ----------
-        T : float
-            Temperature in :math:`[K]`
-        p : float, optional
-            Pressure in :math:`[Pa]`, by default the atmospheric pressure
-            value, i.e., :math:`101325.0 Pa`
-        verbose : bool, optional
-            `True` to tell the decorator to print a warning message in case of
-            range check failing, `False` otherwise. By default, `False`
-
-        Returns
-        -------
-        float:
-            vapour pressure in :math:`[Pa]`
-        """
-        return LBEIodineHenryConstantNeuhausen2005().correlation(T, p) /\
-            LBEIodineActivityCoefficientNeuhasen2005c().correlation(T, p)
-
-    @property
-    def name(self) -> str:
-        """
-        str : Name of the property
-        """
-        return "P_I"
-
-    @property
-    def units(self) -> str:
-        """
-        str : vapour pressure unit
-        """
-        return "[Pa]"
-
-    @property
-    def long_name(self) -> str:
-        """
-        str : monoatomic Iodine vapour pressure long name
-        """
-        return "Vapour pressure of monoatomic Iodine"
-
-    @property
-    def description(self) -> str:
-        """
-        str : monoatomic Iodine vapour pressure description
-        """
-        return f"{self.long_name} in liquid LBE"
-
-    @property
-    def range(self) -> List[float]:
-        """
-        List[float] : Temperature validity range of the monoatomic Iodine
-        vapour pressure correlation function
-        """
-        return [700, T_b0]
-
-
 class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
     """
     Liquid LBE *Caesium intermetallic compounds activity coefficient* property class
@@ -1148,7 +1453,7 @@ class LBECaesiumActivityCoefficientOhno2006(PropertyInterface):
         """
         str : Caesium intermetallic compounds activity coefficient description
         """
-        return f"{self.long_name} in liquid lead"
+        return f"{self.long_name} in liquid LBE"
 
     @property
     def range(self) -> List[float]:

--- a/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
+++ b/lbh15/properties/lbe_thermochemical_properties/lbe_contamination.py
@@ -1,0 +1,81 @@
+"""Module with the definition of some coumpounds properties
+for contamination assessment"""
+from math import log
+from typing import List
+from scipy.constants import atm
+from ..interface import PropertyInterface
+from ..._decorators import range_warning
+
+
+class LBEPoloniumHenryConstantInterfaceOhno2006(PropertyInterface):
+    """
+    Liquid LBE *Polonium compounds Henry constant* property class
+    implementing the correlation by *ohno2006*.
+    """
+    @range_warning
+    def correlation(self, T: float, p: float = atm,
+                    verbose: bool = False) -> float:
+        """
+        Returns the value of the *Polonium compounds Henry constant* by
+        applying the property correlation.
+
+        Parameters
+        ----------
+        T : float
+            Temperature in :math:`[K]`
+        p : float, optional
+            Pressure in :math:`[Pa]`, by default the atmospheric pressure
+            value, i.e., :math:`101325.0 Pa`
+        verbose : bool, optional
+            `True` to tell the decorator to print a warning message in case of
+            range check failing, `False` otherwise. By default, `False`
+
+        Returns
+        -------
+        float:
+            Henry constant in :math:`[Pa]`
+        """
+        return 10**((- 8348 / T) + 10.5357)
+
+    @property
+    def name(self) -> str:
+        """
+        str : Name of the property
+        """
+        return "K_LBEPo"
+
+    @property
+    def correlation_name(self) -> str:
+        """
+        str : Name of the correlation
+        """
+        return "ohno2006"
+
+    @property
+    def units(self) -> str:
+        """
+        str : Henry constant unit
+        """
+        return "[Pa]"
+
+    @property
+    def long_name(self) -> str:
+        """
+        str : Polonium Henry constant long name
+        """
+        return "Henry constant of Polonium in LBE"
+
+    @property
+    def description(self) -> str:
+        """
+        str : Polonium Henry constant description
+        """
+        return f"{self.long_name} in liquid LBE"
+
+    @property
+    def range(self) -> List[float]:
+        """
+        List[float] : Temperature validity range of the Polonium Henry constant
+        correlation function
+        """
+        return [723.0, 1023.0]


### PR DESCRIPTION
Implementation of the following correlations:

 Polonium Henry constant by Ohno, 2006.

 Mercury Henry constant by Landolt, 1991.

 Cadmium Henry constant by Landolt, 1991.

 Cadmium vapour pressure by Landolt, 1991.

 Thallium Henry constant by Landolt, 1991.

 Thallium vapour pressure by Landolt, 1991.

 Iodine Henry constant by Neuhausen, 2005.

 Caesium activity coefficient by Ohno, 2006.

 Rubidium vapour pressure by Landolt, 1960.

 Rubidium vapour pressure according to the Handbook.