### PR TITLE
Imposed locale in sphinx conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,11 +12,14 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import locale
+locale.setlocale(locale.LC_TIME, 'en_US.utf8')
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 import shutil
 import subprocess
+from datetime import datetime
 from setup import get_info
 from typing import Any
 from typing import Dict


### PR DESCRIPTION
A bug has been identified when compiling the doc on Windows 11 OS: this bug was blocking the compilation process of the doc.
It was related to the default locale used by Sphinx, which was the same as the OS locale.
When the OS used a locale other than the `en_US`, the bug occurred.
To solve such issue, `conf.py` has been changed to force the locale to be `en_US`, regardless of the locale used by the OS.